### PR TITLE
freeze pip requirements into requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+certifi==2017.4.17
+chardet==3.0.4
+future==0.16.0
+idna==2.5
+krakenex==0.1.4
+python-telegram-bot==6.1.0
+requests==2.18.1
+urllib3==1.21.1


### PR DESCRIPTION
- Frozen pip requirements inside of `virtualenv`
- Tested with both `Python 2` and `Python 3`