### PR TITLE
Added multiple items in trades history

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
 	"trade_to_currency" : "EUR",
 	"check_trade" : true,
 	"check_trade_time" : 30,
+    "history_items": 5,
 	"update_url" : "https://raw.githubusercontent.com/endogen/Telegram-Kraken-Bot/master/telegram_kraken_bot.py",
 	"update_hash" : "some_hash",
 	"update_check" : true,

--- a/config.json
+++ b/config.json
@@ -1,26 +1,26 @@
 {
-	"user_id" : "some_telegram_user_id",
-	"bot_token" : "some_bot_token",
-	"trade_to_currency" : "EUR",
-	"check_trade" : true,
-	"check_trade_time" : 30,
+    "user_id" : "some_telegram_user_id",
+    "bot_token" : "some_bot_token",
+    "trade_to_currency" : "EUR",
+    "check_trade" : true,
+    "check_trade_time" : 30,
     "history_items": 5,
-	"update_url" : "https://raw.githubusercontent.com/endogen/Telegram-Kraken-Bot/master/telegram_kraken_bot.py",
-	"update_hash" : "some_hash",
-	"update_check" : true,
-	"update_time" : 86400,
-	"send_error" : false,
-	"show_access_denied" : true,
-	"used_coins" : [
-		"XBT", "BCH", "ETH", "LTC", "XMR", "XRP"
-	],
-	"coin_charts" : {
-		"XBT" : "https://tinyurl.com/y9p6g5a8",
-		"BCH" : "https://tinyurl.com/yas7972g",
-		"ETH" : "https://tinyurl.com/ya3fkha4",
-		"LTC" : "https://tinyurl.com/y8n7ohfh",
-		"XMR" : "https://tinyurl.com/y98ygfuw",
-		"XRP" : "https://tinyurl.com/ya4wcy3h"
-	},
-	"log_to_file" : false
+    "update_url" : "https://raw.githubusercontent.com/endogen/Telegram-Kraken-Bot/master/telegram_kraken_bot.py",
+    "update_hash" : "some_hash",
+    "update_check" : true,
+    "update_time" : 86400,
+    "send_error" : false,
+    "show_access_denied" : true,
+    "used_coins" : [
+        "XBT", "BCH", "ETH", "LTC", "XMR", "XRP"
+    ],
+    "coin_charts" : {
+        "XBT" : "https://tinyurl.com/y9p6g5a8",
+        "BCH" : "https://tinyurl.com/yas7972g",
+        "ETH" : "https://tinyurl.com/ya3fkha4",
+        "LTC" : "https://tinyurl.com/y8n7ohfh",
+        "XMR" : "https://tinyurl.com/y98ygfuw",
+        "XRP" : "https://tinyurl.com/ya4wcy3h"
+    },
+    "log_to_file" : false
 }

--- a/telegram_kraken_bot.py
+++ b/telegram_kraken_bot.py
@@ -884,22 +884,23 @@ def history_cmd(bot, update):
         ]
 
         # Get first item in list (latest trade)
-        newest_trade = next(iter(trades), None)
+        for items in range(config['history_items']):
+            newest_trade = next(iter(trades), None)
 
-        trade_str = (newest_trade["type"] + " " +
-                     trim_zeros(newest_trade["vol"]) + " " +
-                     newest_trade["pair"][1:] + " @ limit " +
-                     trim_zeros(newest_trade["price"]) + " on " +
-                     datetime_from_timestamp(newest_trade["time"]))
+            trade_str = (newest_trade["type"] + " " +
+                        trim_zeros(newest_trade["vol"]) + " " +
+                        newest_trade["pair"][-7:] + " @ limit " +
+                        trim_zeros(newest_trade["price"]) + " on " +
+                        datetime_from_timestamp(newest_trade["time"]))
 
-        total_value = "{0:.2f}".format(float(newest_trade["price"]) * float(newest_trade["vol"]))
+            total_value = "{0:.2f}".format(float(newest_trade["price"]) * float(newest_trade["vol"]))
 
-        msg = trade_str + " (Value: " + total_value + " EUR)"
-        reply_mrk = ReplyKeyboardMarkup(build_menu(buttons, n_cols=1, footer_buttons=cancel_btn))
-        update.message.reply_text(bold(msg), reply_markup=reply_mrk, parse_mode=ParseMode.MARKDOWN)
+            msg = trade_str + " (Value: " + total_value + " EUR)"
+            reply_mrk = ReplyKeyboardMarkup(build_menu(buttons, n_cols=1, footer_buttons=cancel_btn))
+            update.message.reply_text(bold(msg), reply_markup=reply_mrk, parse_mode=ParseMode.MARKDOWN)
 
-        # Remove the first item in the trades list
-        trades.remove(newest_trade)
+            # Remove the first item in the trades list
+            trades.remove(newest_trade)
 
         return WorkflowEnum.HISTORY_NEXT
     else:
@@ -912,21 +913,22 @@ def history_cmd(bot, update):
 def history_next(bot, update):
     if trades:
         # Get first item in list (latest trade)
-        newest_trade = next(iter(trades), None)
+        for items in range(config['history_items']):
+            newest_trade = next(iter(trades), None)
 
-        trade_str = (newest_trade["type"] + " " +
-                     trim_zeros(newest_trade["vol"]) + " " +
-                     newest_trade["pair"][1:] + " @ limit " +
-                     trim_zeros(newest_trade["price"]) + " on " +
-                     datetime_from_timestamp(newest_trade["time"]))
+            trade_str = (newest_trade["type"] + " " +
+                        trim_zeros(newest_trade["vol"]) + " " +
+                        newest_trade["pair"][-7:] + " @ limit " +
+                        trim_zeros(newest_trade["price"]) + " on " +
+                        datetime_from_timestamp(newest_trade["time"]))
 
-        total_value = "{0:.2f}".format(float(newest_trade["price"]) * float(newest_trade["vol"]))
+            total_value = "{0:.2f}".format(float(newest_trade["price"]) * float(newest_trade["vol"]))
 
-        msg = trade_str + " (Value: " + total_value + " EUR)"
-        update.message.reply_text(bold(msg), parse_mode=ParseMode.MARKDOWN)
+            msg = trade_str + " (Value: " + total_value + " EUR)"
+            update.message.reply_text(bold(msg), parse_mode=ParseMode.MARKDOWN)
 
-        # Remove the first item in the trades list
-        trades.remove(newest_trade)
+            # Remove the first item in the trades list
+            trades.remove(newest_trade)
 
         return WorkflowEnum.HISTORY_NEXT
     else:


### PR DESCRIPTION
Added the possibility to show more than just 1 item when calling `/history`.
The amount that the user want to show can be adjusted in the `config.json` file.
This has been added because when setting a limit order, sometimes this is only partially filled.
Every partially filled order will show up in the history list.
So there might be 6 partial orders for one limit order you placed, by setting a default of showing 5 
orders strikes a nice balance.

Another small fix is when showing DASH or Bitcoin cash transactions in the order history.
`newest_trade["pair"][1:]` cuts off the first character in these transactions.
However `newest_trade["pair"][-7:]` is a quick fix, 
although being able to show `XBTEUR` instead of `XBTZEUR` would look more appeasing.